### PR TITLE
Use ChaCha20-Poly1305 instead of AES

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "A simple and high level library to encrypt and decrypt texts, files, folders and any data with it"
 documentation = "https://docs.rs/simple_crypt"
 repository = "https://github.com/NiiightmareXD/simple_crypt"
-keywords = ["crypto", "encryption", "aes", "argon2", "cypher"]
+keywords = ["crypto", "encryption", "chacha20", "poly1305", "argon2", "cypher"]
 categories = ["cryptography"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aes-gcm-siv = "0.11.1"
 serde = "1.0.143"
 serde_derive = "1.0.143"
 rust-argon2 = "1.0.0"
@@ -22,3 +21,4 @@ bincode = "1.3.3"
 anyhow = "1.0.60"
 log = "0.4.17"
 tar = "0.4.38"
+chacha20poly1305 = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Simple Crypt
 
 A simple and high-level rust library to encrypt and decrypt texts, files, folders and any data with it
-For encryption, it uses [AES-GCM-SIV-256](https://en.wikipedia.org/wiki/AES-GCM-SIV) and [Argon2](https://en.wikipedia.org/wiki/Argon2)
+For encryption, it uses [ChaCha20-Poly1305](https://en.wikipedia.org/wiki/ChaCha20-Poly1305) and [Argon2](https://en.wikipedia.org/wiki/Argon2)
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! `simple_crypt` is a high-level library to encrypt and decrypt data
 //!
-//! For encryption it uses [AES-GCM-SIV-256](https://en.wikipedia.org/wiki/AES-GCM-SIV) and [Argon2](https://en.wikipedia.org/wiki/Argon2)
+//! For encryption it uses [ChaCha20-Poly1305](https://en.wikipedia.org/wiki/ChaCha20-Poly1305) and [Argon2](https://en.wikipedia.org/wiki/Argon2)
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
I made it so encryption and decryption uses ChaCha20-Poly1305 instead of AES. ChaCha20 is more modern and less complex than AES, decreasing the attack surface, as well as increasing the speed of cryptography. I also updated all mentions of AES in documentation.