### PR TITLE
Remove suggestion to use a wildcard version selector in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ For encryption, it uses [ChaCha20-Poly1305](https://en.wikipedia.org/wiki/ChaCha
 
 ## Usage
 
-add this to Cargo.toml:
-
-```toml
-simple_crypt = "*"
-```
+add this package to your Cargo.toml by running: `cargo add simple_crypt`
 
 ## Examples
 


### PR DESCRIPTION
Libraries should never use wildcard version selectors for their dependencies. As such, it is a bad idea to suggest that in your readme. This pull request replaces that suggestion with a suggestion to use `cargo add`, which will automatically add the latest version of your dependency.

https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies